### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,13 @@
 setting.py
+*.lps
+*.compiled
+*.[oa]
+*.ppu
+*.rst
+*.cgi
+*.exe
+*.log
+*.bak*
+fp.ini
+fp.cfg
+fp.dsk


### PR DESCRIPTION
¿Qué ha cambiado?
Agregamos al gitignore soporta para Node.js
- [ ] Frontend
- [ ] Backend
- [x ] Configuración del server

# ¿Cómo puedo probar los cambios?
Por ejemplo los archivos y la carpeta node_modules ya no se suben al repo, ver archivo .gitignore
